### PR TITLE
[mkcal] Restrict event reminder automatic snoozing to 2 times

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -619,6 +619,7 @@ void ExtendedStorage::setAlarms( const Incidence::Ptr &incidence )
     Timed::Event& e = events.append();
     alarmNumer++;
     e.setUserModeFlag();
+    e.setMaximalTimeoutSnoozeCounter( 2 );
     if ( alarmTime.isUtc() ) {
       e.setTicker( alarmTime.toTime_t() );
     } else {
@@ -878,6 +879,7 @@ void ExtendedStorage::Private::setAlarms( const Incidence::Ptr &incidence, Timed
     }
     Timed::Event& e = events.append();
     e.setUserModeFlag();
+    e.setMaximalTimeoutSnoozeCounter( 2 );
     if ( alarmTime.isUtc() ) {
       e.setTicker( alarmTime.toTime_t() );
     } else {


### PR DESCRIPTION
Set the timed enabler for maximum number of snoozes that the event reminder can be automatically snoozed as a result of user inactivity. If the user does not respond to the event reminder for a third time, then timed will dismiss the reminder. The event reminder will be shown a total of three times in case the user does not react to it.

Note: setting maximal timeout snooze counter does not automatically provide autosnoozing functionality, it facilitates it. If the flag is set, then calling Maemo::Timed::Interface:dialog_response_async(<cookie> , 0), where the last parameter indicates "closed due to user inactivity" will increse the automatic snooze counter, and so automatic snoozing/dismissing.

This pull request depends on this timed PR: https://github.com/nemomobile/timed/pull/48, update spec file accordingly and merge after the timed PR is merged.
