### PR TITLE
[mkcal] Extend storages alarm priming functionality.

### DIFF
--- a/libmkcal-qt5.pc
+++ b/libmkcal-qt5.pc
@@ -6,7 +6,7 @@ includedir=${prefix}/include/mkcal-qt5
 
 Name: Mkcal-qt5
 Description: Maemo mkcal calendar library
-Version: 0.3.11
+Version: 0.3.18
 Libs: -L${libdir} -lmkcal-qt5 
 Libs.private: -luuid -lical -licalss -licalvcal -lsqlite3 -L/usr/lib/ -lkcalcoren-qt5 -lQtSparql-qt5 -lQt5Network -L/usr/lib -lQt5DBus -lQt5Core -lpthread   
 Cflags:  -I${includedir}

--- a/rpm/mkcal-qt5.spec
+++ b/rpm/mkcal-qt5.spec
@@ -1,7 +1,7 @@
 Name:       mkcal-qt5
 
 Summary:    Extended KDE kcal calendar library port for Maemo
-Version:    0.3.13
+Version:    0.3.18
 Release:    1
 Group:      System/Libraries
 License:    LGPLV2

--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -642,6 +642,21 @@ class MKCAL_EXPORT ExtendedStorage
     void setAlarms( const KCalCore::Incidence::Ptr &incidence );
 
     /**
+      Used to remove primed alarms for given notebook from timed
+
+      @param notebookUid notebook uid
+    */
+    void clearAlarms(const QString &notebookUid);
+
+    /**
+      Used to block timed alarm priming for given list of notebooks. Applies
+      to setAlarms & resetAlarms methods.
+
+      @param notebookUids list of notebook uids that should not get alarms primed
+    */
+    void blockAlarms(const QStringList &notebookUids);
+
+    /**
       Creates and sets a default notebook. Usually called for an empty
       calendar.
 
@@ -661,6 +676,8 @@ class MKCAL_EXPORT ExtendedStorage
     */
     virtual void virtual_hook( int id, void *data ) = 0;
 
+
+
   protected:
     virtual bool loadNotebooks() = 0;
     virtual bool reloadNotebooks() = 0;
@@ -677,7 +694,6 @@ class MKCAL_EXPORT ExtendedStorage
     void setFinished( bool error, const QString &info );
     void clearAlarms( const KCalCore::Incidence::Ptr &incidence );
     void clearAlarms( const KCalCore::Incidence::List &incidences );
-    void clearAlarms( const QString &nname );
 
     bool isUncompletedTodosLoaded();
     void setIsUncompletedTodosLoaded( bool loaded );

--- a/src/src.pro
+++ b/src/src.pro
@@ -28,7 +28,7 @@ CONFIG(debug,debug|release) {
 TEMPLATE = lib
 equals(QT_MAJOR_VERSION, 4): TARGET = mkcal
 equals(QT_MAJOR_VERSION, 5): TARGET = mkcal-qt5
-VERSION+= 0.3.13
+VERSION+= 0.3.18
 
 DEPENDPATH += . \
     klibport \


### PR DESCRIPTION
- Add clearAlarms method to storage public API.
- Add method to block alarm priming for list of notebook uids.
- Prevent storage to prime alarms for listed notebooks.