### PR TITLE
[mkcal] fix build with no previous installation existing

### DIFF
--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,7 +1,18 @@
 QT += testlib
 CONFIG += link_pkgconfig c++11
 
-PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5 libical
+INCLUDEPATH +=  ../src
+QMAKE_LIBDIR += ../src
+
+equals(QT_MAJOR_VERSION, 4) {
+  LIBS += -lmkcal
+  PKGCONFIG += libkcalcoren libical
+}
+equals(QT_MAJOR_VERSION, 5) {
+  LIBS += -lmkcal-qt5
+  PKGCONFIG += libkcalcoren-qt5 libical
+}
+
 
 HEADERS += \
     tst_storage.h

--- a/tools/mkcaltool/mkcaltool.pro
+++ b/tools/mkcaltool/mkcaltool.pro
@@ -5,7 +5,18 @@ target.path = /usr/bin
 
 CONFIG += link_pkgconfig
 
-PKGCONFIG += libkcalcoren-qt5 libmkcal-qt5
+INCLUDEPATH +=  ../../src
+QMAKE_LIBDIR += ../../src
+
+equals(QT_MAJOR_VERSION, 4) {
+  LIBS += -lmkcal
+  PKGCONFIG += libkcalcoren
+}
+equals(QT_MAJOR_VERSION, 5) {
+  LIBS += -lmkcal-qt5
+  PKGCONFIG += libkcalcoren-qt5
+}
+
 
 SOURCES += main.cpp \
     mkcaltool.cpp


### PR DESCRIPTION
yeah, cannot really use pkgconfig if no installation yet exists.
