### PR TITLE
[mkcal] Fix ExtendedCalendar::rawExpandedEvents() to return all events b...

### DIFF
--- a/src/extendedcalendar.cpp
+++ b/src/extendedcalendar.cpp
@@ -1016,7 +1016,7 @@ ExtendedCalendar::ExpandedIncidenceList ExtendedCalendar::rawExpandedEvents( con
 
   KDateTime::Spec ts = timespec.isValid() ? timespec : timeSpec();
   KDateTime ksdt( start, ts );
-  KDateTime kedt = KDateTime( end, ts ).addSecs( 24 * 3600 - 1 ); // End of day
+  KDateTime kedt = KDateTime( end, QTime(23, 59, 59), ts );
 
   // Iterate over all events. Look for recurring events that occur on this date
   QHashIterator<QString,Event::Ptr>i( d->mEvents );

--- a/tests/tst_storage.h
+++ b/tests/tst_storage.h
@@ -27,6 +27,7 @@ private slots:
   void tst_alldayUtc();
   void tst_alldayRecurrence();
   void tst_origintimes();
+  void tst_rawEvents();
 
 private:
   void openDb(bool clear = false);


### PR DESCRIPTION
...etween interval

KDateTime(end, ts).addSecs() was used to set day end. The ctor, however,
creates a date-only instance, for which adding seconds less than a day
is a no-op.
