### PR TITLE
[mkcal] Work around invalid recurrence data on sqlite

### DIFF
--- a/src/sqliteformat.cpp
+++ b/src/sqliteformat.cpp
@@ -1571,7 +1571,11 @@ bool SqliteFormat::Private::selectRecursives( Incidence::Ptr incidence, int rowi
         }
       }
 
-      recurrule->setDuration(sqlite3_column_int(stmt, 6));  // count
+      int duration = sqlite3_column_int(stmt, 6);  // count
+      if (duration == 0 && !recurrule->endDt().isValid()) {
+        duration = -1; // work around invalid recurrence state: recurring infinitely but having invalid end date
+      }
+      recurrule->setDuration(duration);
       // Frequency
       recurrule->setFrequency(sqlite3_column_int(stmt, 7)); // interval-field
 


### PR DESCRIPTION
It's possible to create invalid recurrence state by
event->recurrence()->setEndDate(QDate()). Event keeps having occurrences
but duration() says there's an end set. recursAt() and getNextDateTime()
don't return them, however.

Fix such broken state when reading recurrence data.
