### PR TITLE
[compilation] Fix compilation on glibc 2.19/gcc 4.8

### DIFF
--- a/src/extendedstorage.h
+++ b/src/extendedstorage.h
@@ -649,8 +649,8 @@ class MKCAL_EXPORT ExtendedStorage
       @param color notebook's color in format "#FF0042", if empty default used
       @return pointer to the created notebook
     */
-    Notebook::Ptr createDefaultNotebook( QString name = "",
-                                         QString color = "");
+    Notebook::Ptr createDefaultNotebook( QString name = QString(),
+                                         QString color = QString());
 
     /**
       Standard trick to add virtuals later.


### PR DESCRIPTION
This was blocking builds of software which relies on
QT_NO_CAST_FROM_ASCII
like contactsd, that fails to build without this patch
