### PR TITLE
[mkcal] Clear alarms by uid and recurrence id. Fixes JB#26458

### DIFF
--- a/src/extendedstorage.cpp
+++ b/src/extendedstorage.cpp
@@ -763,6 +763,13 @@ void ExtendedStorage::clearAlarms( const KCalCore::Incidence::List &incidences )
     const QList<QVariant> &result = reply.value();
     for ( int i = 0; i < result.size(); i++ ) {
       uint32_t cookie = result[i].toUInt();
+      if ( !incidence->hasRecurrenceId() ) {
+        QDBusReply<QMap<QString, QVariant> > attributesReply = timed.query_attributes_sync( cookie );
+        const QMap<QString, QVariant> attributeMap = attributesReply.value();
+        if ( attributeMap.contains( "recurrenceId" ) ) {
+          continue;
+        }
+      }
       kDebug() << "removing alarm" << cookie << incidence->uid()
           << ( incidence->hasRecurrenceId() ? incidence->recurrenceId().toString() : "-" );
       QDBusReply<bool> reply = timed.cancel_sync( cookie );


### PR DESCRIPTION
Do not remove timed alarms by uid only if the alarm has a recurrence id.

Timed alarms always have the uid attribute and may have the recurrenceId attribute as well. If the recurrenceId attribute is present, then it is used together with the uid attribute to identify the alarm.