### PR TITLE
[mkcal] Use directory as semaphore ftok id.  Contributes to MER#1246

### DIFF
--- a/src/semaphore_p.cpp
+++ b/src/semaphore_p.cpp
@@ -33,6 +33,7 @@
 
 #include <errno.h>
 #include <unistd.h>
+#include <libgen.h>
 
 #include <sys/sem.h>
 #include <sys/stat.h>
@@ -61,7 +62,10 @@ int semaphoreInit(const char *id, size_t count, const int *initialValues)
     int rv = -1;
 
     // the specific value of proj_id is unimportant except that it must be non-zero, so 5?
-    key_t key = ::ftok(id, 5);
+    char *filepath = ::strdup(id);
+    char *dirpath = ::dirname(filepath);
+    key_t key = ::ftok(dirpath, 5);
+    ::free(filepath);
 
     rv = ::semget(key, count, 0);
     if (rv == -1) {


### PR DESCRIPTION
This commit ensures that we use the directory path as the semaphore
ftok id rather than the full db file path, as the db file path may not
yet exist if the database has not yet been created.

Contributes to MER#1246
